### PR TITLE
Drop deprecated proc-macro-hack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = [".", "codegen-exports", "codegen"]
 
 [package]
 name = "include-flate"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["SOFe <sofe2038@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/SOF3/include-flate.git"
 homepage = "https://github.com/SOF3/include-flate"
@@ -14,12 +14,12 @@ categories = ["compression", "rust-patterns", "memory-management"]
 keywords = ["compression", "deflate", "macro", "include", "assets"]
 
 [dependencies]
-include-flate-codegen-exports = { version = "0.1.4", path = "codegen-exports" }
-lazy_static = "1.3"
-libflate = "1.0.0"
+include-flate-codegen-exports = { version = "0.2.0", path = "codegen-exports" }
+lazy_static = "1.3.0"
+libflate = "2.0.0"
 
 [badges]
 travis-ci = {repository = "SOF3/include-flate"}
 
 [features]
-stable = ["include-flate-codegen-exports/stable"]
+stable = []

--- a/codegen-exports/Cargo.toml
+++ b/codegen-exports/Cargo.toml
@@ -1,16 +1,12 @@
 [package]
 name = "include-flate-codegen-exports"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["SOFe <sofe2038@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/SOF3/include-flate.git"
 homepage = "https://github.com/SOF3/include-flate"
 description = "Macro codegen for the include-flate crate"
 
 [dependencies]
-include-flate-codegen = { version = "0.1.4", path = "../codegen" }
-proc-macro-hack = "0.5.9"
-
-[features]
-stable = ["include-flate-codegen/stable"]
+include-flate-codegen = { version = "0.2.0", path = "../codegen" }

--- a/codegen-exports/src/lib.rs
+++ b/codegen-exports/src/lib.rs
@@ -1,5 +1,2 @@
-#[cfg_attr(feature = "stable", proc_macro_hack::proc_macro_hack)]
 pub use include_flate_codegen::deflate_file;
-
-#[cfg_attr(feature = "stable", proc_macro_hack::proc_macro_hack)]
 pub use include_flate_codegen::deflate_utf8_file;

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -12,7 +12,7 @@ description = "Macro codegen for the include-flate crate"
 proc-macro = true
 
 [dependencies]
-libflate = "1.0.0"
+libflate = "2.0.0"
 proc-macro2 = "1.0.9"
 quote = "1.0.2"
 syn = { version = "2.0.2", features = ["full"] }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "include-flate-codegen"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["SOFe <sofe2038@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/SOF3/include-flate.git"
 homepage = "https://github.com/SOF3/include-flate"
@@ -13,10 +13,6 @@ proc-macro = true
 
 [dependencies]
 libflate = "1.0.0"
-proc-macro-hack = { version = "0.5.9", optional = true }
 proc-macro2 = "1.0.9"
 quote = "1.0.2"
 syn = { version = "2.0.2", features = ["full"] }
-
-[features]
-stable = ["proc-macro-hack"]

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_span))]
-
 extern crate proc_macro;
 
 use std::fs::File;
@@ -43,8 +41,7 @@ use syn::{Error, LitByteStr, LitStr, Result};
 /// # Compile errors
 /// - If the argument is not a single literal
 /// - If the referenced file does not exist or is not readable
-#[cfg_attr(feature = "stable", proc_macro_hack::proc_macro_hack)]
-#[cfg_attr(not(feature = "stable"), proc_macro)]
+#[proc_macro]
 pub fn deflate_file(ts: TokenStream) -> TokenStream {
     match inner(ts, false) {
         Ok(ts) => ts.into(),
@@ -57,8 +54,7 @@ pub fn deflate_file(ts: TokenStream) -> TokenStream {
 /// # Compile errors
 /// - The compile errors in `deflate_file!`
 /// - If the file contents are not all valid UTF-8
-#[cfg_attr(feature = "stable", proc_macro_hack::proc_macro_hack)]
-#[cfg_attr(not(feature = "stable"), proc_macro)]
+#[proc_macro]
 pub fn deflate_utf8_file(ts: TokenStream) -> TokenStream {
     match inner(ts, true) {
         Ok(ts) => ts.into(),

--- a/tests/base64-raw.rs
+++ b/tests/base64-raw.rs
@@ -19,5 +19,5 @@ pub static DATA: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/asset
 
 #[test]
 fn test() {
-    verify_str("base64.txt", &DATA);
+    verify_str("base64.txt", DATA);
 }

--- a/tests/ff-raw.rs
+++ b/tests/ff-raw.rs
@@ -19,5 +19,5 @@ pub static DATA: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/as
 
 #[test]
 fn test() {
-    verify("ff.dat", &DATA);
+    verify("ff.dat", DATA);
 }

--- a/tests/random-raw.rs
+++ b/tests/random-raw.rs
@@ -19,5 +19,5 @@ pub static DATA: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/as
 
 #[test]
 fn test() {
-    verify("random.dat", &DATA);
+    verify("random.dat", DATA);
 }

--- a/tests/zero-raw.rs
+++ b/tests/zero-raw.rs
@@ -19,5 +19,5 @@ pub static DATA: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/as
 
 #[test]
 fn test() {
-    verify("zero.dat", &DATA);
+    verify("zero.dat", DATA);
 }


### PR DESCRIPTION
These changes do up the actual MSRV to at least Rust 1.45, but that was released 3 years ago on `July 16, 2020` so it shouldn't be an issue. I did a version bump anyway due to the MSRV bump and the updated 2021 edition is more constricting anyway.

From the `proc-macro-hack` crate:
> As of Rust 1.45 this crate is superseded by native support for #[proc_macro] in expression position. Only consider using this crate if you care about supporting compilers between 1.31 and 1.45.

Dropping this crate and using the std `#[proc_macro]` lets it build on stable Rust by default, without flags. The `stable` feature is still included due to the flags in the test modules, but has no actual impact on the code - I'm not sure what to do about it, but you _can_ remove the `stable` feature and everything works if you delete the requirement of the nightly only feature in the tests.

+ Dropped `proc-macro-hack`
+ Updated to the latest edition, `2021` (not required to compile on stable, could revert)
+ Updated `libflate` to 2.0 (not required to compile on stable, could revert)
+ Bumped version to `0.3.0` due to MSRV bump
