### PR TITLE
Use `once_cell` instead of `lazy_static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ keywords = ["compression", "deflate", "macro", "include", "assets"]
 
 [dependencies]
 include-flate-codegen = { version = "0.2.0", path = "codegen" }
-lazy_static = "1.3.0"
+once_cell = "1.18.0"
 libflate = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "codegen"]
 
 [package]
 name = "include-flate"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["SOFe <sofe2038@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fail_tests/009f-str.rs
+++ b/fail_tests/009f-str.rs
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/009f.rs
+++ b/tests/009f.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/ascii-control.rs
+++ b/tests/ascii-control.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/ascii-printable.rs
+++ b/tests/ascii-printable.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/base64.rs
+++ b/tests/base64.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/chinese.rs
+++ b/tests/chinese.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/emoji.rs
+++ b/tests/emoji.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/ff.rs
+++ b/tests/ff.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;

--- a/tests/zero.rs
+++ b/tests/zero.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 include!("../test_util.rs");
 
 use include_flate::flate;


### PR DESCRIPTION
The `once_cell` crate looks like it will become the standard very soon, as part of its code has already been merged into Rust's std. This PR moves to use the crate's `Lazy` type instead of the `lazy_static` macro.

The end-user shouldn't notice any changes, but if the `Lazy` type does get merged into the std then that's one less dependency needed (unless you're working with no std)

It also removes all the `#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]` from the tests.

Feel free to ignore this PR if you still like `lazy_static`