### PR TITLE
Add Zstd support as optional and compile-time low ratio report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         stability:
           - ""
           - "--release"
+        feature:
+          - default
+          - deflate
+          - zstd
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -33,4 +37,4 @@ jobs:
           profile: default
           default: true
       - name: cargo clippy
-        run: "cargo clippy --all ${{matrix.stability}}"
+        run: "cargo clippy --all --features ${{matrix.feature}} ${{matrix.stability}}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
           - ""
           - "--release"
         feature:
-          - default
-          - deflate
-          - zstd
+          - ""
+          - "--no-default-features --features deflate"
+          - "--no-default-features --features zstd"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -37,4 +37,4 @@ jobs:
           profile: default
           default: true
       - name: cargo clippy
-        run: "cargo clippy --all --features ${{matrix.feature}} ${{matrix.stability}}"
+        run: "cargo clippy --all ${{matrix.feature}} ${{matrix.stability}}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,12 @@ jobs:
           - beta
           - nightly
         stability:
-          - ""
-          - "--release"
+          - ''
+          - '--release'
+        feature:
+          - default
+          - deflate
+          - zstd
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -33,4 +37,4 @@ jobs:
           profile: default
           default: true
       - name: cargo clippy
-        run: "cargo clippy --all ${{matrix.stability}}"
+        run: 'cargo clippy --all --features ${{matrix.feature}} ${{matrix.stability}}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,8 @@ jobs:
           - beta
           - nightly
         stability:
-          - ''
-          - '--release'
-        feature:
-          - default
-          - deflate
-          - zstd
+          - ""
+          - "--release"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -37,4 +33,4 @@ jobs:
           profile: default
           default: true
       - name: cargo clippy
-        run: 'cargo clippy --all --features ${{matrix.feature}} ${{matrix.stability}}'
+        run: "cargo clippy --all ${{matrix.stability}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "codegen"]
+members = [".", "codegen", "compress"]
 
 [package]
 name = "include-flate"
@@ -15,11 +15,7 @@ keywords = ["compression", "deflate", "macro", "include", "assets"]
 
 [dependencies]
 include-flate-codegen = { version = "0.2.0", path = "codegen" }
+include-flate-compress = { version = "0.1.0", path = "compress" }
 once_cell = "1.18.0"
-libflate = { version = "2.0.0", optional = true }
-zstd = { version = "0.13.0", optional = true }
-
-[features]
-default = ["deflate"]
-deflate = ["include-flate-codegen/deflate", "dep:libflate"]
-zstd = ["include-flate-codegen/zstd", "dep:zstd"]
+libflate = "2.0.0"
+zstd = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,10 @@ keywords = ["compression", "deflate", "macro", "include", "assets"]
 [dependencies]
 include-flate-codegen = { version = "0.2.0", path = "codegen" }
 once_cell = "1.18.0"
-libflate = "2.0.0"
+libflate = { version = "2.0.0", optional = false }
+zstd = { version = "0.13.0", optional = false }
+
+[features]
+default = ["deflate"]
+deflate = ["include-flate-codegen/deflate"]
+zstd = ["include-flate-codegen/zstd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ keywords = ["compression", "deflate", "macro", "include", "assets"]
 [dependencies]
 include-flate-codegen = { version = "0.2.0", path = "codegen" }
 once_cell = "1.18.0"
-libflate = { version = "2.0.0", optional = false }
-zstd = { version = "0.13.0", optional = false }
+libflate = { version = "2.0.0", optional = true }
+zstd = { version = "0.13.0", optional = true }
 
 [features]
 default = ["deflate"]
-deflate = ["include-flate-codegen/deflate"]
-zstd = ["include-flate-codegen/zstd"]
+deflate = ["include-flate-codegen/deflate", "dep:libflate"]
+zstd = ["include-flate-codegen/zstd", "dep:zstd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,7 @@ libflate = "2.0.0"
 zstd = "0.13.0"
 
 [features]
-default = []
+default = ["deflate", "zstd"]
+deflate = ["include-flate-compress/deflate"]
+zstd = ["include-flate-compress/zstd"]
 no-compression-warnings = ["include-flate-codegen/no-compression-warnings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ include-flate-compress = { version = "0.1.0", path = "compress" }
 once_cell = "1.18.0"
 libflate = "2.0.0"
 zstd = "0.13.0"
+
+[features]
+default = []
+no-compression-warnings = ["include-flate-codegen/no-compression-warnings"]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -18,3 +18,4 @@ quote = "1.0.2"
 syn = { version = "2.0.2", features = ["full"] }
 zstd = "0.13.0"
 include-flate-compress = { version = "0.1.0", path = "../compress" }
+proc-macro-error = "1.0.4"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -19,3 +19,7 @@ syn = { version = "2.0.2", features = ["full"] }
 zstd = "0.13.0"
 include-flate-compress = { version = "0.1.0", path = "../compress" }
 proc-macro-error = "1.0.4"
+
+[features]
+default = []
+no-compression-warnings = []

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -12,14 +12,9 @@ description = "Macro codegen for the include-flate crate"
 proc-macro = true
 
 [dependencies]
-libflate = { version = "2.0.0", optional = true }
+libflate = "2.0.0"
 proc-macro2 = "1.0.9"
 quote = "1.0.2"
 syn = { version = "2.0.2", features = ["full"] }
-zstd = { version = "0.13.0", optional = true }
-
-[features]
-# default is intentional to avoid conflict from parent crate feature selection.
-default = []
-deflate = ["dep:libflate"]
-zstd = ["dep:zstd"]
+zstd = "0.13.0"
+include-flate-compress = { version = "0.1.0", path = "../compress" }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -12,7 +12,14 @@ description = "Macro codegen for the include-flate crate"
 proc-macro = true
 
 [dependencies]
-libflate = "2.0.0"
+libflate = { version = "2.0.0", optional = false }
 proc-macro2 = "1.0.9"
 quote = "1.0.2"
 syn = { version = "2.0.2", features = ["full"] }
+zstd = { version = "0.13.0", optional = false }
+
+[features]
+# default is intentional to avoid conflict from parent crate feature selection.
+default = []
+deflate = []
+zstd = []

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -12,14 +12,14 @@ description = "Macro codegen for the include-flate crate"
 proc-macro = true
 
 [dependencies]
-libflate = { version = "2.0.0", optional = false }
+libflate = { version = "2.0.0", optional = true }
 proc-macro2 = "1.0.9"
 quote = "1.0.2"
 syn = { version = "2.0.2", features = ["full"] }
-zstd = { version = "0.13.0", optional = false }
+zstd = { version = "0.13.0", optional = true }
 
 [features]
 # default is intentional to avoid conflict from parent crate feature selection.
 default = []
-deflate = []
-zstd = []
+deflate = ["dep:libflate"]
+zstd = ["dep:zstd"]

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -153,19 +153,22 @@ fn inner(ts: TokenStream, utf8: bool) -> syn::Result<impl Into<TokenStream>> {
     let bytes = LitByteStr::new(&compressed_buffer, Span::call_site());
     let result = quote!(#bytes);
 
-    let compression_ratio = calculate_compression_ratio(
-        file.metadata().unwrap().file_size(),
-        compressed_buffer.len() as u64,
-    );
+    #[cfg(not(feature = "no-compression-warnings"))]
+    {
+        let compression_ratio = calculate_compression_ratio(
+            file.metadata().unwrap().file_size(),
+            compressed_buffer.len() as u64,
+        );
 
-    if compression_ratio < 10.0f64 {
-        emit_warning!(
+        if compression_ratio < 10.0f64 {
+            emit_warning!(
             &args.path,
             "Detected low compression ratio ({:.2}%) for file {:?} with `{:?}`. Consider using other compression methods.",
             compression_ratio,
             path.display(),
             algo,
         );
+        }
     }
 
     Ok(result)

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -87,7 +87,6 @@ fn inner(ts: TokenStream, utf8: bool) -> Result<impl Into<TokenStream>> {
 
     let mut file = File::open(target).map_err(emap)?;
     let before = file.metadata().unwrap().len();
-    println!("before size: {:#X}", before);
 
     let mut vec = Vec::<u8>::new();
     if utf8 {

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -101,7 +101,7 @@ impl TryFrom<Ident> for CompressionMethodTy {
     }
 }
 
-fn calculate_compression_ratio(original_size: u64, compressed_size: u64) -> f64 {
+fn compression_ratio(original_size: u64, compressed_size: u64) -> f64 {
     (compressed_size as f64 / original_size as f64) * 100.0
 }
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -15,9 +15,8 @@
 
 extern crate proc_macro;
 
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{Read, Seek};
-use std::os::windows::prelude::MetadataExt;
 use std::path::PathBuf;
 use std::str::{from_utf8, FromStr};
 
@@ -161,7 +160,7 @@ fn inner(ts: TokenStream, utf8: bool) -> syn::Result<impl Into<TokenStream>> {
     #[cfg(not(feature = "no-compression-warnings"))]
     {
         let compression_ratio = compression_ratio(
-            file.metadata().unwrap().file_size(),
+            fs::metadata(&target).map_err(emap)?.len(),
             compressed_buffer.len() as u64,
         );
 

--- a/compress/Cargo.toml
+++ b/compress/Cargo.toml
@@ -9,5 +9,10 @@ homepage = "https://github.com/SOF3/include-flate"
 description = "Compression algorithm provider"
 
 [dependencies]
-libflate = "2.0.0"
-zstd = "0.13.0"
+libflate = { version = "2.0.0", optional = true }
+zstd = { version = "0.13.0", optional = true }
+
+[features]
+default = ["deflate", "zstd"]
+deflate = ["dep:libflate"]
+zstd = ["dep:zstd"]

--- a/compress/Cargo.toml
+++ b/compress/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "include-flate-compress"
+version = "0.1.0"
+authors = ["SOFe <sofe2038@gmail.com>", "Kento Oki <hrn832@protonmail.com>"]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/SOF3/include-flate.git"
+homepage = "https://github.com/SOF3/include-flate"
+description = "Compression algorithm provider"
+
+[dependencies]
+libflate = "2.0.0"
+zstd = "0.13.0"

--- a/compress/src/lib.rs
+++ b/compress/src/lib.rs
@@ -1,0 +1,198 @@
+// include-flate
+// Copyright (C) SOFe, Kento Oki
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    fmt,
+    io::{self, BufRead, BufReader, Read, Seek, Write},
+    str::FromStr,
+};
+
+use libflate::deflate::Decoder as DeflateDecoder;
+use libflate::deflate::Encoder as DeflateEncoder;
+use zstd::Decoder as ZstdDecoder;
+use zstd::Encoder as ZstdEncoder;
+
+#[derive(Debug)]
+pub enum FlateCompressionError {
+    DeflateError(io::Error),
+    ZstdError(io::Error),
+    IoError(io::Error),
+}
+
+impl From<io::Error> for FlateCompressionError {
+    fn from(err: io::Error) -> Self {
+        FlateCompressionError::IoError(err)
+    }
+}
+
+impl fmt::Display for FlateCompressionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FlateCompressionError::DeflateError(err) => write!(f, "Deflate error: {}", err),
+            FlateCompressionError::ZstdError(err) => write!(f, "Zstd error: {}", err),
+            FlateCompressionError::IoError(err) => write!(f, "I/O error: {}", err),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum CompressionMethod {
+    Deflate,
+    Zstd,
+}
+
+impl CompressionMethod {
+    pub fn encoder<'a, W: BufRead + Write + Seek + 'a>(
+        &'a self,
+        write: W,
+    ) -> Result<FlateEncoder<'a, W>, FlateCompressionError> {
+        FlateEncoder::new(*self, write)
+    }
+
+    pub fn decoder<'a, R: ReadSeek + 'a>(
+        &'a self,
+        read: R,
+    ) -> Result<FlateDecoder<'a>, FlateCompressionError> {
+        FlateDecoder::new(*self, Box::new(read))
+    }
+}
+
+impl Default for CompressionMethod {
+    fn default() -> Self {
+        Self::Deflate
+    }
+}
+
+impl FromStr for CompressionMethod {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match &*s.to_lowercase() {
+            "deflate" => Ok(CompressionMethod::Deflate),
+            "zstd" => Ok(CompressionMethod::Zstd),
+            _ => Err(format!("Unknown compression method: {}", s).into()),
+        }
+    }
+}
+
+pub enum FlateEncoder<'a, W: Write + 'a> {
+    Deflate(DeflateEncoder<W>),
+    Zstd(ZstdEncoder<'a, W>),
+}
+
+impl<'a, W: BufRead + Write + Seek + 'a> FlateEncoder<'a, W> {
+    pub fn new(
+        method: CompressionMethod,
+        write: W,
+    ) -> Result<FlateEncoder<'a, W>, FlateCompressionError> {
+        match method {
+            CompressionMethod::Deflate => Ok(FlateEncoder::Deflate(DeflateEncoder::new(write))),
+            CompressionMethod::Zstd => ZstdEncoder::new(write, 0)
+                .map(FlateEncoder::Zstd)
+                .map_err(|e| FlateCompressionError::ZstdError(e)),
+        }
+    }
+}
+
+impl<'a, W: Write + 'a> Write for FlateEncoder<'a, W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            FlateEncoder::Deflate(encoder) => encoder.write(buf),
+            FlateEncoder::Zstd(encoder) => encoder.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            FlateEncoder::Deflate(encoder) => encoder.flush(),
+            FlateEncoder::Zstd(encoder) => encoder.flush(),
+        }
+    }
+}
+
+impl<'a, W: Write + 'a> FlateEncoder<'a, W> {
+    fn finish_encode(self) -> Result<W, FlateCompressionError> {
+        match self {
+            FlateEncoder::Deflate(encoder) => encoder
+                .finish()
+                .into_result()
+                .map_err(|e| FlateCompressionError::DeflateError(e)),
+            FlateEncoder::Zstd(encoder) => encoder
+                .finish()
+                .map_err(|e| FlateCompressionError::ZstdError(e)),
+        }
+    }
+}
+
+pub trait ReadSeek: BufRead + Seek {}
+
+impl<T: BufRead + Seek> ReadSeek for T {}
+
+pub enum FlateDecoder<'a> {
+    Deflate(DeflateDecoder<Box<dyn BufRead + 'a>>),
+    Zstd(ZstdDecoder<'a, BufReader<Box<dyn BufRead + 'a>>>),
+}
+
+impl<'a> FlateDecoder<'a> {
+    pub fn new(
+        method: CompressionMethod,
+        read: Box<dyn BufRead + 'a>,
+    ) -> Result<FlateDecoder<'a>, FlateCompressionError> {
+        match method {
+            CompressionMethod::Deflate => Ok(FlateDecoder::Deflate(DeflateDecoder::new(read))),
+            CompressionMethod::Zstd => {
+                let decoder = ZstdDecoder::new(read)?;
+                Ok(FlateDecoder::Zstd(decoder))
+            }
+        }
+    }
+}
+
+impl<'a> Read for FlateDecoder<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            FlateDecoder::Deflate(decoder) => decoder.read(buf),
+            FlateDecoder::Zstd(decoder) => decoder.read(buf),
+        }
+    }
+}
+
+pub fn apply_compression<R: Sized, W: Sized + BufRead + Seek>(
+    reader: &mut R,
+    writer: &mut W,
+    method: CompressionMethod,
+) -> Result<(), FlateCompressionError>
+where
+    R: Read,
+    W: Write,
+{
+    let mut encoder = method.encoder(writer)?;
+    io::copy(reader, &mut encoder)?;
+    encoder.finish_encode().map(|_| ())
+}
+
+pub fn apply_decompression<R: Sized + BufRead + Seek, W: Sized>(
+    reader: &mut R,
+    writer: &mut W,
+    method: CompressionMethod,
+) -> Result<(), FlateCompressionError>
+where
+    R: Read,
+    W: Write,
+{
+    let mut decoder = method.decoder(reader)?;
+    io::copy(&mut decoder, writer)?;
+    Ok(())
+}

--- a/compress/src/lib.rs
+++ b/compress/src/lib.rs
@@ -81,6 +81,20 @@ impl CompressionMethod {
     }
 }
 
+#[cfg(any(feature = "deflate", feature = "zstd"))]
+impl Default for CompressionMethod {
+    fn default() -> Self {
+        #[cfg(feature = "deflate")]
+        {
+            Self::Deflate
+        }
+        #[cfg(all(not(feature = "deflate"), feature = "zstd"))]
+        {
+            Self::Zstd
+        }
+    }
+}
+
 pub enum FlateEncoder<W: Write> {
     #[cfg(feature = "deflate")]
     Deflate(DeflateEncoder<W>),

--- a/fail_tests/009f-str.rs
+++ b/fail_tests/009f-str.rs
@@ -18,6 +18,8 @@ include!("../test_util.rs");
 use include_flate::flate;
 
 flate!(pub static DATA: str from "assets/009f.dat");
+flate!(pub static DATA: str from "assets/009f.dat" with deflate);
+flate!(pub static DATA: str from "assets/009f.dat" with zstd);
 
 #[test]
 fn test() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,16 +26,13 @@
 //! which might be undesirable if the data are too large.
 //! An actual installer is still required if the binary involves too many resources that do not need to be kept in RAM all time.
 
-#[cfg(all(feature = "deflate", feature = "zstd"))]
-compile_error!("You cannot enable both `deflate` and `zstd` at the same time.");
-#[cfg(not(any(feature = "zstd", feature = "deflate")))]
-compile_error!("You must enable either the `deflate` or `zstd` feature.");
-
-#[cfg(feature = "deflate")]
-use libflate::deflate;
-
 /// The low-level macros used by this crate.
 pub use include_flate_codegen as codegen;
+use include_flate_compress::apply_decompression;
+
+#[doc(hidden)]
+pub use include_flate_compress::CompressionMethod;
+
 #[doc(hidden)]
 pub use once_cell::sync::Lazy;
 
@@ -99,49 +96,62 @@ pub use once_cell::sync::Lazy;
 #[macro_export]
 macro_rules! flate {
     ($(#[$meta:meta])*
-        $(pub $(($($vis:tt)+))?)? static $name:ident: [u8] from $path:literal) => {
+        $(pub $(($($vis:tt)+))?)? static $name:ident: [u8] from $path:literal $(with $algo:ident)?) => {
         // HACK: workaround to make cargo auto rebuild on modification of source file
         const _: &'static [u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path));
 
         $(#[$meta])*
-        $(pub $(($($vis)+))?)? static $name: $crate::Lazy<::std::vec::Vec<u8>> = $crate::Lazy::new(|| $crate::decode($crate::codegen::deflate_file!($path)));
+        $(pub $(($($vis)+))?)? static $name: $crate::Lazy<::std::vec::Vec<u8>> = $crate::Lazy::new(|| {
+            $crate::decode($crate::codegen::deflate_file!($path), None)
+        });
     };
     ($(#[$meta:meta])*
-        $(pub $(($($vis:tt)+))?)? static $name:ident: str from $path:literal) => {
+        $(pub $(($($vis:tt)+))?)? static $name:ident: str from $path:literal $(with $algo:ident)?) => {
         // HACK: workaround to make cargo auto rebuild on modification of source file
         const _: &'static str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path));
 
         $(#[$meta])*
-        $(pub $(($($vis)+))?)? static $name: $crate::Lazy<::std::string::String> = $crate::Lazy::new(|| $crate::decode_string($crate::codegen::deflate_utf8_file!($path)));
+        $(pub $(($($vis)+))?)? static $name: $crate::Lazy<::std::string::String> = $crate::Lazy::new(|| {
+            let algo = match stringify!($($algo)?){
+                "deflate" => $crate::CompressionMethod::Deflate,
+                "zstd" => $crate::CompressionMethod::Zstd,
+                _ => $crate::CompressionMethod::default(),
+            };
+            $crate::decode_string($crate::codegen::deflate_utf8_file!($path $($algo)?), Some($crate::CompressionMethodTy(algo)))
+        });
     };
 }
 
-#[doc(hidden)]
-pub fn decode(bytes: &[u8]) -> Vec<u8> {
-    use std::io::{Cursor, Read};
+#[derive(Debug)]
+pub struct CompressionMethodTy(pub CompressionMethod);
 
+impl Into<CompressionMethod> for CompressionMethodTy {
+    fn into(self) -> CompressionMethod {
+        self.0
+    }
+}
+
+#[doc(hidden)]
+#[allow(private_interfaces)]
+pub fn decode(bytes: &[u8], algo: Option<CompressionMethodTy>) -> Vec<u8> {
+    use std::io::Cursor;
+
+    let algo: CompressionMethod = algo
+        .unwrap_or(CompressionMethodTy(CompressionMethod::Deflate))
+        .into();
+    let mut source = Cursor::new(bytes);
     let mut ret = Vec::new();
 
-    #[cfg(feature = "zstd")]
-    {
-        let mut dec = zstd::stream::Decoder::new(Cursor::new(bytes)).unwrap();
-        dec.read_to_end(&mut ret)
-            .expect("Compiled ZSTD buffer was corrupted");
-    }
-
-    #[cfg(feature = "deflate")]
-    {
-        let mut dec = deflate::Decoder::new(Cursor::new(bytes));
-        dec.read_to_end(&mut ret)
-            .expect("Compiled DEFLATE buffer was corrupted");
-    }
+    apply_decompression(&mut source, &mut ret, algo)
+        .expect(&format!("Compiled `{:?}` buffer was corrupted", algo));
 
     ret
 }
 
 #[doc(hidden)]
-pub fn decode_string(bytes: &[u8]) -> String {
+#[allow(private_interfaces)]
+pub fn decode_string(bytes: &[u8], algo: Option<CompressionMethodTy>) -> String {
     // We should have checked for utf8 correctness in encode_utf8_file!
-    String::from_utf8(decode(bytes))
+    String::from_utf8(decode(bytes, algo))
         .expect("flate_str has malformed UTF-8 despite checked at compile time")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,10 @@ pub fn decode(bytes: &[u8], algo: Option<CompressionMethodTy>) -> Vec<u8> {
     let mut source = Cursor::new(bytes);
     let mut ret = Vec::new();
 
-    apply_decompression(&mut source, &mut ret, algo)
-        .expect(&format!("Compiled `{:?}` buffer was corrupted", algo));
+    match apply_decompression(&mut source, &mut ret, algo) {
+        Ok(_) => {}
+        Err(err) => panic!("Compiled `{:?}` buffer was corrupted: {:?}", algo, err),
+    }
 
     ret
 }

--- a/test_util.rs
+++ b/test_util.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::str::from_utf8;
 

--- a/test_util.rs
+++ b/test_util.rs
@@ -14,21 +14,59 @@
 // limitations under the License.
 
 use std::fs::File;
-use std::path::PathBuf;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
 use std::str::from_utf8;
 
-pub fn read_file(name: &str) -> Vec<u8> {
-    let path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("assets").join(name);
+use include_flate_compress::{apply_compression, apply_decompression, CompressionMethod};
+
+pub fn get_file_path<P: AsRef<Path>>(relative_from: Option<&Path>, path: P) -> PathBuf {
+    let cargo_manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let default_base_path = Path::new(&cargo_manifest_dir);
+    let base_path = relative_from.unwrap_or_else(|| default_base_path);
+    base_path.join("assets").join(path)
+}
+
+pub fn read_file<P: AsRef<Path>>(name: P) -> Vec<u8> {
+    let path = get_file_path(None, name);
     let mut vec = Vec::<u8>::new();
     std::io::copy(&mut File::open(path).unwrap(), &mut vec).unwrap();
     vec
 }
 
-pub fn verify(name: &str, data: &[u8]) {
-    assert_eq!(read_file(name), data);
+pub fn verify_compression<P: AsRef<Path>>(name: P, data: &[u8], method: CompressionMethod) {
+    let path = get_file_path(None, &name);
+    let mut file = File::open(&path).unwrap();
+    let mut file_buffer = Vec::new();
+    file.read_to_end(&mut file_buffer).unwrap();
+    let mut source = std::io::Cursor::new(file_buffer);
+    let mut compressed_buffer = Vec::new();
+    {
+        let mut compressed_cursor = std::io::Cursor::new(&mut compressed_buffer);
+        apply_compression(&mut source, &mut compressed_cursor, method).unwrap();
+        compressed_cursor.seek(SeekFrom::Start(0)).unwrap(); // Reset cursor position
+    }
+    assert_ne!(compressed_buffer.as_slice(), data);
+    let mut decompressed_buffer = Vec::new();
+    {
+        let mut compressed_cursor = std::io::Cursor::new(&mut compressed_buffer);
+        let mut decompressed_cursor = std::io::Cursor::new(&mut decompressed_buffer);
+        apply_decompression(&mut compressed_cursor, &mut decompressed_cursor, method).unwrap();
+        decompressed_cursor.seek(SeekFrom::Start(0)).unwrap(); // Reset cursor position
+    }
+    assert_ne!(compressed_buffer.as_slice(), decompressed_buffer.as_slice());
+}
+
+pub fn verify<P: AsRef<Path>>(name: P, data: &[u8]) {
+    verify_compression(&name, data, CompressionMethod::Deflate);
+    verify_compression(&name, data, CompressionMethod::Zstd);
+    assert_eq!(read_file(&name), data);
 }
 
 pub fn verify_str(name: &str, data: &str) {
     // But the file should not have compiled in the first place
-    assert_eq!(from_utf8(&read_file(name)).expect("File is not encoded"), data);
+    assert_eq!(
+        from_utf8(&read_file(name)).expect("File is not encoded"),
+        data
+    );
 }

--- a/tests/009f.rs
+++ b/tests/009f.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: [u8] from "assets/009f.dat");
+flate!(pub static DATA1: [u8] from "assets/009f.dat");
+flate!(pub static DATA2: [u8] from "assets/009f.dat" with deflate);
+flate!(pub static DATA3: [u8] from "assets/009f.dat" with zstd);
 
 #[test]
 fn test() {
-    verify("009f.dat", &DATA);
+    verify("009f.dat", &DATA1);
+    verify("009f.dat", &DATA2);
+    verify("009f.dat", &DATA3);
 }

--- a/tests/ascii-control.rs
+++ b/tests/ascii-control.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: str from "assets/ascii-printable.txt");
+flate!(pub static DATA1: str from "assets/ascii-printable.txt");
+flate!(pub static DATA2: str from "assets/ascii-printable.txt" with deflate);
+flate!(pub static DATA3: str from "assets/ascii-printable.txt" with zstd);
 
 #[test]
 fn test() {
-    verify_str("ascii-printable.txt", &DATA);
+    verify_str("ascii-printable.txt", &DATA1);
+    verify_str("ascii-printable.txt", &DATA2);
+    verify_str("ascii-printable.txt", &DATA3);
 }

--- a/tests/ascii-printable.rs
+++ b/tests/ascii-printable.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: str from "assets/ascii-printable.txt");
+flate!(pub static DATA1: str from "assets/ascii-printable.txt");
+flate!(pub static DATA2: str from "assets/ascii-printable.txt" with deflate);
+flate!(pub static DATA3: str from "assets/ascii-printable.txt" with zstd);
 
 #[test]
 fn test() {
-    verify_str("ascii-printable.txt", &DATA);
+    verify_str("ascii-printable.txt", &DATA1);
+    verify_str("ascii-printable.txt", &DATA2);
+    verify_str("ascii-printable.txt", &DATA3);
 }

--- a/tests/base64.rs
+++ b/tests/base64.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: str from "assets/base64.txt");
+flate!(pub static DATA1: str from "assets/base64.txt");
+flate!(pub static DATA2: str from "assets/base64.txt" with deflate);
+flate!(pub static DATA3: str from "assets/base64.txt" with zstd);
 
 #[test]
 fn test() {
-    verify_str("base64.txt", &DATA);
+    verify_str("base64.txt", &DATA1);
+    verify_str("base64.txt", &DATA2);
+    verify_str("base64.txt", &DATA3);
 }

--- a/tests/chinese.rs
+++ b/tests/chinese.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: str from "assets/chinese.txt");
+flate!(pub static DATA1: str from "assets/chinese.txt");
+flate!(pub static DATA2: str from "assets/chinese.txt" with deflate);
+flate!(pub static DATA3: str from "assets/chinese.txt" with zstd);
 
 #[test]
 fn test() {
-    verify_str("chinese.txt", &DATA);
+    verify_str("chinese.txt", &DATA1);
+    verify_str("chinese.txt", &DATA2);
+    verify_str("chinese.txt", &DATA3);
 }

--- a/tests/emoji.rs
+++ b/tests/emoji.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: str from "assets/emoji.txt");
+flate!(pub static DATA1: str from "assets/emoji.txt");
+flate!(pub static DATA2: str from "assets/emoji.txt" with deflate);
+flate!(pub static DATA3: str from "assets/emoji.txt" with zstd);
 
 #[test]
 fn test() {
-    verify_str("emoji.txt", &DATA);
+    verify_str("emoji.txt", &DATA1);
+    verify_str("emoji.txt", &DATA2);
+    verify_str("emoji.txt", &DATA3);
 }

--- a/tests/ff.rs
+++ b/tests/ff.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: [u8] from "assets/ff.dat");
+flate!(pub static DATA1: [u8] from "assets/ff.dat");
+flate!(pub static DATA2: [u8] from "assets/ff.dat" with deflate);
+flate!(pub static DATA3: [u8] from "assets/ff.dat" with zstd);
 
 #[test]
 fn test() {
-    verify("ff.dat", &DATA);
+    verify("ff.dat", &DATA1);
+    verify("ff.dat", &DATA2);
+    verify("ff.dat", &DATA3);
 }

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: [u8] from "assets/random.dat");
+flate!(pub static DATA1: [u8] from "assets/random.dat");
+flate!(pub static DATA2: [u8] from "assets/random.dat" with deflate);
+flate!(pub static DATA3: [u8] from "assets/random.dat" with zstd);
 
 #[test]
 fn test() {
-    verify("random.dat", &DATA);
+    verify("random.dat", &DATA1);
+    verify("random.dat", &DATA2);
+    verify("random.dat", &DATA3);
 }

--- a/tests/zero.rs
+++ b/tests/zero.rs
@@ -17,9 +17,13 @@ include!("../test_util.rs");
 
 use include_flate::flate;
 
-flate!(pub static DATA: [u8] from "assets/zero.dat");
+flate!(pub static DATA1: [u8] from "assets/zero.dat");
+flate!(pub static DATA2: [u8] from "assets/zero.dat" with deflate);
+flate!(pub static DATA3: [u8] from "assets/zero.dat" with zstd);
 
 #[test]
 fn test() {
-    verify("zero.dat", &DATA);
+    verify("zero.dat", &DATA1);
+    verify("zero.dat", &DATA2);
+    verify("zero.dat", &DATA3);
 }


### PR DESCRIPTION
Zstd (*ZStandard*) is a fast real-time compression algorithm.

~~I've added Zstd support in compression/decompression as optional. Users can select which one to use by specifying feature flags: `zstd` and `deflate`.~~

```toml
# Cargo.toml
[dependencies]
include-flate = { version = "...", default-features = false, features = ["zstd"] }
# or
include-flate = { version = "...", default-features = false, features = ["deflate"] } # this is same as default.
```

In summary, while DEFLATE is a venerable and widely adopted algorithm, Zstd provides significant advantages in speed and compression ratio, would make it a strong choice for crates or binaries that can support it.

### ~~Testing this PR~~

~~Since I've modified `Cargo.toml` to not use unnecessary dependency, multiple vectors of tests needed:~~

```
cargo test --all
```

```
cargo test --no-default-features --features deflate
```

```
cargo test --no-default-features --features zstd
```