### PR TITLE
Upgrade to Rust 2024 edition and remove `once_cell` dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "codegen", "compress"]
 [workspace.package]
 version = "0.3.0"
 authors = ["SOFe <sofe2038@gmail.com>"]
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/SOF3/include-flate.git"
 homepage = "https://github.com/SOF3/include-flate"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ include = ["/src", "/LICENSE", "/README.md"]
 [dependencies]
 include-flate-codegen = { version = "0.3.0", path = "codegen" }
 include-flate-compress = { version = "0.3.0", path = "compress" }
-once_cell = "1.18.0"
 libflate = { workspace = true }
 zstd = { workspace = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,26 @@
 [workspace]
 members = [".", "codegen", "compress"]
 
-[package]
-name = "include-flate"
+[workspace.package]
 version = "0.3.0"
 authors = ["SOFe <sofe2038@gmail.com>"]
 edition = "2021"
-license = "Apache-2.0"
 repository = "https://github.com/SOF3/include-flate.git"
 homepage = "https://github.com/SOF3/include-flate"
+license = "Apache-2.0"
+
+[workspace.dependencies]
+libflate = "2.1.0"
+zstd = "0.13.3"
+
+[package]
+name = "include-flate"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "A variant of include_bytes!/include_str! with compile-time deflation and runtime lazy inflation"
 categories = ["compression", "rust-patterns", "memory-management"]
 keywords = ["compression", "deflate", "macro", "include", "assets"]
@@ -18,8 +30,8 @@ include = ["/src", "/LICENSE", "/README.md"]
 include-flate-codegen = { version = "0.3.0", path = "codegen" }
 include-flate-compress = { version = "0.3.0", path = "compress" }
 once_cell = "1.18.0"
-libflate = "2.0.0"
-zstd = "0.13.0"
+libflate = { workspace = true }
+zstd = { workspace = true }
 
 [features]
 default = ["deflate", "zstd"]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "include-flate-codegen"
-version = "0.3.0"
-authors = ["SOFe <sofe2038@gmail.com>"]
-edition = "2021"
-license = "Apache-2.0"
-repository = "https://github.com/SOF3/include-flate.git"
-homepage = "https://github.com/SOF3/include-flate"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Macro codegen for the include-flate crate"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-libflate = "2.0.0"
-proc-macro2 = "1.0.9"
-quote = "1.0.2"
-syn = { version = "2.0.2", features = ["full"] }
-zstd = "0.13.0"
+libflate = { workspace = true }
+proc-macro2 = "1.0.95"
+quote = "1.0.40"
+syn = { version = "2.0.104", features = ["full"] }
+zstd = { workspace = true }
 include-flate-compress = { version = "0.3.0", path = "../compress" }
 proc-macro-error = "1.0.4"
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -18,12 +18,12 @@ extern crate proc_macro;
 use std::fs::{self, File};
 use std::io::{Read, Seek};
 use std::path::PathBuf;
-use std::str::{from_utf8, FromStr};
+use std::str::{FromStr, from_utf8};
 
-use include_flate_compress::{apply_compression, CompressionMethod};
+use include_flate_compress::{CompressionMethod, apply_compression};
 use proc_macro::TokenStream;
-use proc_macro2::Span;
 use proc_macro_error::{emit_warning, proc_macro_error};
+use proc_macro2::Span;
 use quote::quote;
 use syn::{Error, LitByteStr};
 
@@ -166,12 +166,12 @@ fn inner(ts: TokenStream, utf8: bool) -> syn::Result<impl Into<TokenStream>> {
 
         if compression_ratio < 10.0f64 {
             emit_warning!(
-            &args.path,
-            "Detected low compression ratio ({:.2}%) for file {:?} with `{:?}`. Consider using other compression methods.",
-            compression_ratio,
-            path.display(),
-            algo.0,
-        );
+                &args.path,
+                "Detected low compression ratio ({:.2}%) for file {:?} with `{:?}`. Consider using other compression methods.",
+                compression_ratio,
+                path.display(),
+                algo.0,
+            );
         }
     }
 

--- a/compress/Cargo.toml
+++ b/compress/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "include-flate-compress"
-version = "0.3.0"
+version.workspace = true
 authors = ["SOFe <sofe2038@gmail.com>", "Kento Oki <hrn832@protonmail.com>"]
-edition = "2021"
-license = "Apache-2.0"
-repository = "https://github.com/SOF3/include-flate.git"
-homepage = "https://github.com/SOF3/include-flate"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Compression algorithm provider"
 
 [dependencies]
-libflate = { version = "2.0.0", optional = true }
-zstd = { version = "0.13.0", optional = true }
+libflate = { workspace = true, optional = true }
+zstd = { workspace = true, optional = true }
 
 [features]
 default = ["deflate", "zstd"]

--- a/compress/src/lib.rs
+++ b/compress/src/lib.rs
@@ -113,7 +113,7 @@ impl<'a, W: BufRead + Write + Seek + 'a> FlateEncoder<W> {
             #[cfg(feature = "zstd")]
             CompressionMethod::Zstd => ZstdEncoder::new(write, 0)
                 .map(FlateEncoder::Zstd)
-                .map_err(|e| FlateCompressionError::ZstdError(e)),
+                .map_err(FlateCompressionError::ZstdError),
         }
     }
 }
@@ -145,11 +145,11 @@ impl<'a, W: Write + 'a> FlateEncoder<W> {
             FlateEncoder::Deflate(encoder) => encoder
                 .finish()
                 .into_result()
-                .map_err(|e| FlateCompressionError::DeflateError(e)),
+                .map_err(FlateCompressionError::DeflateError),
             #[cfg(feature = "zstd")]
-            FlateEncoder::Zstd(encoder) => encoder
-                .finish()
-                .map_err(|e| FlateCompressionError::ZstdError(e)),
+            FlateEncoder::Zstd(encoder) => {
+                encoder.finish().map_err(FlateCompressionError::ZstdError)
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,6 @@ use include_flate_compress::apply_decompression;
 #[doc(hidden)]
 pub use include_flate_compress::CompressionMethod;
 
-#[doc(hidden)]
-pub use once_cell::sync::Lazy;
-
 /// This macro is like [`include_bytes!`][1] or [`include_str!`][2], but compresses at compile time
 /// and lazily decompresses at runtime.
 ///
@@ -101,7 +98,7 @@ macro_rules! flate {
         const _: &'static [u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path));
 
         $(#[$meta])*
-        $(pub $(($($vis)+))?)? static $name: $crate::Lazy<::std::vec::Vec<u8>> = $crate::Lazy::new(|| {
+        $(pub $(($($vis)+))?)? static $name: ::std::sync::LazyLock<::std::vec::Vec<u8>> = ::std::sync::LazyLock::new(|| {
             $crate::decode($crate::codegen::deflate_file!($path), None)
         });
     };
@@ -111,7 +108,7 @@ macro_rules! flate {
         const _: &'static str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path));
 
         $(#[$meta])*
-        $(pub $(($($vis)+))?)? static $name: $crate::Lazy<::std::string::String> = $crate::Lazy::new(|| {
+        $(pub $(($($vis)+))?)? static $name: ::std::sync::LazyLock<::std::string::String> = ::std::sync::LazyLock::new(|| {
             let algo = match stringify!($($algo)?){
                 "deflate" => $crate::CompressionMethod::Deflate,
                 "zstd" => $crate::CompressionMethod::Zstd,


### PR DESCRIPTION
1. Use workspace to manage the same meta-information and dependencies for all crates
2. Upgrade to Rust 2024 edition, and remove `once_cell` dep. 'std::sync::LazyLock' is stable in Rust 2024 edition(Rust 1.85)

Closes #27 