### PR TITLE
improve feature flags to exclude usage in sub-crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,15 @@ include = ["/src", "/LICENSE", "/README.md"]
 [dependencies]
 include-flate-codegen = { version = "0.3.1", path = "codegen" }
 include-flate-compress = { version = "0.3.1", path = "compress" }
-libflate = { workspace = true }
-zstd = { workspace = true }
+libflate = { workspace = true, optional = true }
+zstd = { workspace = true, optional = true }
 
 [features]
 default = ["deflate", "zstd"]
-deflate = ["include-flate-compress/deflate"]
-zstd = ["include-flate-compress/zstd"]
+deflate = [
+  "include-flate-compress/deflate",
+  "include-flate-codegen/deflate",
+  "dep:libflate",
+]
+zstd = ["include-flate-compress/zstd", "include-flate-codegen/zstd", "dep:zstd"]
 no-compression-warnings = ["include-flate-codegen/no-compression-warnings"]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -12,14 +12,13 @@ description = "Macro codegen for the include-flate crate"
 proc-macro = true
 
 [dependencies]
-libflate = { workspace = true }
 proc-macro2 = "1.0.95"
 quote = "1.0.40"
 syn = { version = "2.0.104", features = ["full"] }
-zstd = { workspace = true }
 include-flate-compress = { version = "0.3.1", path = "../compress" }
 proc-macro-error = "1.0.4"
 
 [features]
-default = []
+deflate = ["include-flate-compress/deflate"]
+zstd = ["include-flate-compress/zstd"]
 no-compression-warnings = []

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -88,10 +88,22 @@ impl syn::parse::Parse for FlateArgs {
             let lookahead = input.lookahead1();
             if lookahead.peek(kw::deflate) {
                 input.parse::<kw::deflate>()?;
-                Some(CompressionMethodTy(CompressionMethod::Deflate))
+
+                #[cfg(feature = "deflate")]
+                {
+                    Some(CompressionMethodTy(CompressionMethod::Deflate))
+                }
+                #[cfg(not(feature = "deflate"))]
+                return Err(lookahead.error());
             } else if lookahead.peek(kw::zstd) {
                 input.parse::<kw::zstd>()?;
-                Some(CompressionMethodTy(CompressionMethod::Zstd))
+
+                #[cfg(feature = "zstd")]
+                {
+                    Some(CompressionMethodTy(CompressionMethod::Zstd))
+                }
+                #[cfg(not(feature = "zstd"))]
+                return Err(lookahead.error());
             } else {
                 return Err(lookahead.error());
             }
@@ -106,7 +118,7 @@ mod kw {
     syn::custom_keyword!(zstd);
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct CompressionMethodTy(CompressionMethod);
 
 fn compression_ratio(original_size: u64, compressed_size: u64) -> f64 {
@@ -122,9 +134,7 @@ fn inner(ts: TokenStream, utf8: bool) -> syn::Result<impl Into<TokenStream>> {
 
     let args: FlateArgs = syn::parse2::<FlateArgs>(ts.to_owned().into())?;
     let path = PathBuf::from_str(&args.path.value()).map_err(emap)?;
-    let algo = args
-        .algorithm
-        .unwrap_or(CompressionMethodTy(CompressionMethod::Deflate));
+    let algo = args.algorithm.unwrap_or_default();
 
     if path.is_absolute() {
         Err(emap("absolute paths are not supported"))?;

--- a/compress/Cargo.toml
+++ b/compress/Cargo.toml
@@ -13,6 +13,5 @@ libflate = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
 
 [features]
-default = ["deflate", "zstd"]
 deflate = ["dep:libflate"]
 zstd = ["dep:zstd"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ impl IFlate {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CompressionMethodTy(pub CompressionMethod);
 
 impl Into<CompressionMethod> for CompressionMethodTy {
@@ -178,9 +178,7 @@ impl Into<CompressionMethod> for CompressionMethodTy {
 pub fn decode(bytes: &[u8], algo: Option<CompressionMethodTy>) -> Vec<u8> {
     use std::io::Cursor;
 
-    let algo: CompressionMethod = algo
-        .unwrap_or(CompressionMethodTy(CompressionMethod::Deflate))
-        .into();
+    let algo: CompressionMethod = algo.unwrap_or_default().into();
     let mut source = Cursor::new(bytes);
     let mut ret = Vec::new();
 


### PR DESCRIPTION
Hi, I wanted to get rid of calls to a C compiler to simplify cross-compilation in one of my projects. However, I‌ noticed that the `zstd-sys` crate is built even when the `zstd` features is disabled on the `include-flate` crate (`default-features = false, features = ["deflate"]`). I tracked it down to the unconditional dependency from the `codegen` and `compress` subcrates, which don't "see" the features of the top-level crate. 

This PR tries to fix that by marking the dependencies as optional everywhere and passing the features down to the sub-crates. I also had to change a few bits in the source but nothing significant, mostly to ensure that all crates use the same defaults.

Manual testing looks fine; I don't know if it is possible to automate this in a reasonable manner.

Thanks for the handy project btw..