### PR TITLE
chore(codegen): switch to proc-macro-error3

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro2 = "1.0.95"
 quote = "1.0.40"
 syn = { version = "2.0.104", features = ["full"] }
 include-flate-compress = { version = "0.3.1", path = "../compress", default-features = false }
-proc-macro-error2 = "2.0.1"
+proc-macro-error3 = "3.0.2"
 
 [features]
 default = ["deflate", "zstd"]

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -22,7 +22,7 @@ use std::str::{FromStr, from_utf8};
 
 use include_flate_compress::{CompressionMethod, apply_compression};
 use proc_macro::TokenStream;
-use proc_macro_error2::{emit_warning, proc_macro_error};
+use proc_macro_error3::{emit_warning, proc_macro_error};
 use proc_macro2::Span;
 use quote::quote;
 use syn::{Error, LitByteStr};


### PR DESCRIPTION
## Why

`proc-macro-error2` is covered by [RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173) as an unmaintained crate, and its repository is archived.

It also still triggers Rust's [`pub_use_of_private_extern_crate`](https://github.com/rust-lang/rust/issues/127909) future-incompatibility warning:

```text
warning[E0365]: extern crate `proc_macro` is private and cannot be re-exported
```

`proc-macro-error3` is a maintained fork that fixes that warning while preserving the same proc-macro diagnostics API.

## What

This replaces the `include-flate-codegen` dependency on `proc-macro-error2` with `proc-macro-error3` and updates the proc-macro diagnostic import path.

The macro behavior is unchanged.

Closes #37.
